### PR TITLE
Update readme to include sorting the releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ let url = URL(string: "https://github.com/johnsundell/unbox")!
 let releases = Releases.versions(for: url)
 
 // Print the latest version
-print(releases.last)
+print(releases.max)
 ```
 
 Remove all pre-release versions (like `Alpha`, `Beta`, etc):
@@ -23,7 +23,7 @@ let url = URL(string: "https://github.com/johnsundell/unbox)!
 let releases = Releases.versions(for: url).withoutPreReleases()
 
 // Print the latest stable version
-print(releases.last)
+print(releases.max)
 ```
 
 ## Installation


### PR DESCRIPTION
Currently the releases are read in the way that git outputs them, which seems to be sorted alphabetical. If a project changed between the v0.0.0 and 0.0.0 format, this will result in the returned release not being sorted correctly.

The option is to just sort the after loading them, like I am including in the Readme here, or the other option would be to sort it in the versions method before returning.