### PR TITLE
fix: order tags by adding --sort=v:refname

### DIFF
--- a/Sources/Releases.swift
+++ b/Sources/Releases.swift
@@ -35,7 +35,7 @@ public class Releases {
     private static func string(from url: URL) throws -> String {
         do {
             if url.absoluteString.hasSuffix(".git") {
-                return try shellOut(to: "git ls-remote --tags \(url.absoluteString)")
+                return try shellOut(to: "git ls-remote --tags --sort=v:refname \(url.absoluteString)")
             } else {
                 let path = url.absoluteString.replacingOccurrences(of: "file://", with: "")
                 return try shellOut(to: "cd \"\(path)\" && git tag")


### PR DESCRIPTION
This PR attempts to solve a bug where the tags are not sorted properly. An example of the current behaviour is:

```
dc0775d2a3a19b2022768ff5c99c147b22a8a6b6	refs/tags/v6.10.0
e7acbcacb9d037179eeb2820a884fc38e964d11f	refs/tags/v6.2.0
498cf01cc16e44822d2a1573bfcfdb115055c41d	refs/tags/v6.3.0
4e88b9314a14b0944031811f577f4766930bfee6	refs/tags/v6.4.0
c1dcbb37d27fcd805926406811b7026c93e3c16a	refs/tags/v6.4.1
be30a2c82f61ff6ed16dddca4d2dbbd050ddb68f	refs/tags/v6.5.0
c1dcbb37d27fcd805926406811b7026c93e3c16a	refs/tags/v6.5.1
6effff632479737fd6f2de17778eb75760f8059a	refs/tags/v6.6.0
7803079463753af9e40f2f93e595e631757452f1	refs/tags/v6.6.1
2dee4211116d14b53cb7d25f97c0b3dbfbe99128	refs/tags/v6.7.0
8d8d9306a6caa9648390fc39d9ff972bae86abd4	refs/tags/v6.8.0
e421f9395e1a7d54fd8ed67589f9506e49db4c72	refs/tags/v6.8.1
672b2a37271aa37ff6e6268b86a8544a4d99c1bf	refs/tags/v6.9.0
```

By sorting them for v:refname the output becomes 

```
e7acbcacb9d037179eeb2820a884fc38e964d11f	refs/tags/v6.2.0
498cf01cc16e44822d2a1573bfcfdb115055c41d	refs/tags/v6.3.0
4e88b9314a14b0944031811f577f4766930bfee6	refs/tags/v6.4.0
c1dcbb37d27fcd805926406811b7026c93e3c16a	refs/tags/v6.4.1
be30a2c82f61ff6ed16dddca4d2dbbd050ddb68f	refs/tags/v6.5.0
c1dcbb37d27fcd805926406811b7026c93e3c16a	refs/tags/v6.5.1
6effff632479737fd6f2de17778eb75760f8059a	refs/tags/v6.6.0
7803079463753af9e40f2f93e595e631757452f1	refs/tags/v6.6.1
2dee4211116d14b53cb7d25f97c0b3dbfbe99128	refs/tags/v6.7.0
8d8d9306a6caa9648390fc39d9ff972bae86abd4	refs/tags/v6.8.0
e421f9395e1a7d54fd8ed67589f9506e49db4c72	refs/tags/v6.8.1
672b2a37271aa37ff6e6268b86a8544a4d99c1bf	refs/tags/v6.9.0
dc0775d2a3a19b2022768ff5c99c147b22a8a6b6	refs/tags/v6.10.0
```